### PR TITLE
feat: add Modal component, fix Header/Footer, use auth selector

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -1,3 +1,77 @@
-export default function Footer() {
-  return;
-}
+import { NavLink, useLocation, useNavigate } from "react-router-dom";
+import { useSelector } from "react-redux";
+import { useState } from "react";
+import { selectUser } from "../../redux/auth/selectors";
+import css from "./Footer.module.css";
+import Logo from "../Logo/Logo.jsx";
+import Modal from "../Modal/Modal"; // твій універсальний Modal
+
+const Footer = () => {
+  const user = useSelector(selectUser);
+  const isLoggedIn = !!user;
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const [authModalOpen, setAuthModalOpen] = useState(false);
+
+  return (
+    <footer className={css.footer}>
+      <div className={css.container}>
+        <Logo />
+
+        <p className={css.copyright}>
+          © {new Date().getFullYear()} CookingCompanion. All rights reserved.
+        </p>
+
+        <div className={css.nav}>
+          <NavLink to="/" className={css.link}>
+            Recipes
+          </NavLink>
+
+          {isLoggedIn ? (
+            <NavLink to="/profile" className={css.link}>
+              Profile
+            </NavLink>
+          ) : (
+            !location.pathname.includes("/auth") && (
+              <button
+                type="button"
+                className={css.link}
+                onClick={() => setAuthModalOpen(true)}
+              >
+                Profile
+              </button>
+            )
+          )}
+        </div>
+      </div>
+
+      {authModalOpen && (
+        <Modal title="Authorization required" onClose={() => setAuthModalOpen(false)}>
+          <p>You need to log in or register to view your profile.</p>
+          <div className={css.modalActions}>
+            <button
+              onClick={() => {
+                setAuthModalOpen(false);
+                navigate("/auth/login");
+              }}
+            >
+              Log in
+            </button>
+            <button
+              onClick={() => {
+                setAuthModalOpen(false);
+                navigate("/auth/register");
+              }}
+            >
+              Register
+            </button>
+          </div>
+        </Modal>
+      )}
+    </footer>
+  );
+};
+
+export default Footer;
+

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -1,6 +1,6 @@
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { selectUser } from "../../redux/auth/selectors";
 import css from "./Footer.module.css";
 import Logo from "../../assets/img/logo.svg";
@@ -14,19 +14,29 @@ const Footer = () => {
 
   const [authModalOpen, setAuthModalOpen] = useState(false);
 
+  const openAuthModal = useCallback(() => setAuthModalOpen(true), []);
+  const closeAuthModal = useCallback(() => setAuthModalOpen(false), []);
+
+  const year = new Date().getFullYear();
+
   return (
     <footer className={css.footer}>
       <div className={css.container}>
-        <div className={css.logoBlock} onClick={() => navigate("/")}>
-          <img src={Logo} alt="Logo" className={css.logo} />
-          <span className={css.logoText}>CookingCompanion</span>
-        </div>
+        <button
+          type="button"
+          className={css.logoBlock}
+          onClick={() => navigate("/")}
+          aria-label="Go to home"
+        >
+          <img src={Logo} alt="" className={css.logo} width={24} height={24} />
+          <span className={css.logoText}>Tasteorama</span>
+        </button>
 
         <p className={css.copyright}>
-          © {new Date().getFullYear()} CookingCompanion. All rights reserved.
+          © {year} Tasteorama. All rights reserved.
         </p>
 
-        <div className={css.nav}>
+        <nav className={css.nav} aria-label="Footer navigation">
           <NavLink to="/" className={css.link}>
             Recipes
           </NavLink>
@@ -40,30 +50,32 @@ const Footer = () => {
               <button
                 type="button"
                 className={css.link}
-                onClick={() => setAuthModalOpen(true)}
+                onClick={openAuthModal}
               >
                 Account
               </button>
             )
           )}
-        </div>
+        </nav>
       </div>
 
       {authModalOpen && (
-        <Modal title="Authorization required" onClose={() => setAuthModalOpen(false)}>
+        <Modal title="Authorization required" onClose={closeAuthModal}>
           <p>You need to log in or register to view your account.</p>
           <div className={css.modalActions}>
             <button
+              type="button"
               onClick={() => {
-                setAuthModalOpen(false);
+                closeAuthModal();
                 navigate("/auth/login");
               }}
             >
               Log in
             </button>
             <button
+              type="button"
               onClick={() => {
-                setAuthModalOpen(false);
+                closeAuthModal();
                 navigate("/auth/register");
               }}
             >
@@ -77,6 +89,7 @@ const Footer = () => {
 };
 
 export default Footer;
+
 
 
 

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -3,7 +3,8 @@ import { useSelector } from "react-redux";
 import { useState } from "react";
 import { selectUser } from "../../redux/auth/selectors";
 import css from "./Footer.module.css";
-import Modal from "../Modal/Modal";
+import Logo from "../../assets/img/logo.svg";
+import Modal from "../../shared/Modal/Modal";
 
 const Footer = () => {
   const user = useSelector(selectUser);
@@ -16,14 +17,10 @@ const Footer = () => {
   return (
     <footer className={css.footer}>
       <div className={css.container}>
-        {}
-        <img
-          src="/assets/img/logo.svg"
-          alt="Logo"
-          className={css.logo}
-          onClick={() => navigate("/")}
-          style={{ cursor: "pointer" }}
-        />
+        <div className={css.logoBlock} onClick={() => navigate("/")}>
+          <img src={Logo} alt="Logo" className={css.logo} />
+          <span className={css.logoText}>CookingCompanion</span>
+        </div>
 
         <p className={css.copyright}>
           © {new Date().getFullYear()} CookingCompanion. All rights reserved.
@@ -36,7 +33,7 @@ const Footer = () => {
 
           {isLoggedIn ? (
             <NavLink to="/profile" className={css.link}>
-              Profile
+              Account
             </NavLink>
           ) : (
             !location.pathname.includes("/auth") && (
@@ -45,7 +42,7 @@ const Footer = () => {
                 className={css.link}
                 onClick={() => setAuthModalOpen(true)}
               >
-                Profile
+                Account
               </button>
             )
           )}
@@ -54,7 +51,7 @@ const Footer = () => {
 
       {authModalOpen && (
         <Modal title="Authorization required" onClose={() => setAuthModalOpen(false)}>
-          <p>You need to log in or register to view your profile.</p>
+          <p>You need to log in or register to view your account.</p>
           <div className={css.modalActions}>
             <button
               onClick={() => {
@@ -80,5 +77,6 @@ const Footer = () => {
 };
 
 export default Footer;
+
 
 

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -3,8 +3,7 @@ import { useSelector } from "react-redux";
 import { useState } from "react";
 import { selectUser } from "../../redux/auth/selectors";
 import css from "./Footer.module.css";
-import Logo from "../Logo/Logo.jsx";
-import Modal from "../Modal/Modal"; // твій універсальний Modal
+import Modal from "../Modal/Modal";
 
 const Footer = () => {
   const user = useSelector(selectUser);
@@ -17,7 +16,14 @@ const Footer = () => {
   return (
     <footer className={css.footer}>
       <div className={css.container}>
-        <Logo />
+        {}
+        <img
+          src="/assets/img/logo.svg"
+          alt="Logo"
+          className={css.logo}
+          onClick={() => navigate("/")}
+          style={{ cursor: "pointer" }}
+        />
 
         <p className={css.copyright}>
           © {new Date().getFullYear()} CookingCompanion. All rights reserved.
@@ -74,4 +80,5 @@ const Footer = () => {
 };
 
 export default Footer;
+
 

--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -1,0 +1,113 @@
+.footer {
+  background-color: #3d2218;
+  color: #fff;
+  padding: 24px 0;
+}
+
+.container {
+  max-width: 393px;
+  margin: 0 auto;
+  padding: 0 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.copyright {
+  font-size: 12px;
+  font-weight: 400;
+  margin-top: 32px;
+  margin-bottom: 32px;
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 40px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.link {
+  color: #fff;
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 0.3s ease;
+}
+
+.link:hover,
+.link:focus-visible {
+  color: #f5e4d0; /* легке підсвічування */
+}
+
+/* ==== Tablet ==== */
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+    padding: 0 32px;
+  }
+
+  .nav {
+    flex-direction: row;
+    gap: 32px;
+  }
+}
+
+/* ==== Desktop ==== */
+@media (min-width: 1440px) {
+  .container {
+    max-width: 1440px;
+    padding: 0 108px;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .copyright {
+    margin: 0;
+  }
+
+  .nav {
+    flex-direction: row;
+    gap: 32px;
+  }
+}
+
+/* ==== Modal Actions ==== */
+.modalActions {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.modalActions button {
+  border: 1px solid #000;
+  border-radius: 8px;
+  padding: 12px 20px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.modalActions button:first-child {
+  background: none;
+  color: #000;
+}
+
+.modalActions button:first-child:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.modalActions button:last-child {
+  background-color: #c80000;
+  color: #fff;
+  border: none;
+}
+
+.modalActions button:last-child:hover {
+  background-color: #a10f0f;
+}

--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -12,29 +12,39 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
+  gap: 24px;
+}
+
+.logoBlock {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
 }
 
 .logo {
   height: 24px;
-  cursor: pointer;
 }
 
-@media (min-width: 768px) {
-  .logo { height: 28px; }
+.logoText {
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  color: #fff;
 }
 
 .copyright {
   font-size: 12px;
   font-weight: 400;
-  margin-top: 32px;
-  margin-bottom: 32px;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.7); /* 👈 як у макеті, не чисто білий */
 }
 
 .nav {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 40px;
+  gap: 44px; /* 👈 по макету */
   font-size: 16px;
   font-weight: 600;
 }
@@ -48,7 +58,7 @@
 
 .link:hover,
 .link:focus-visible {
-  color: #f5e4d0; 
+  color: #f5e4d0;
 }
 
 .link:focus-visible {
@@ -61,11 +71,20 @@
   .container {
     max-width: 768px;
     padding: 0 32px;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    text-align: left;
+  }
+
+  .logo {
+    height: 28px;
   }
 
   .nav {
     flex-direction: row;
     gap: 32px;
+    font-size: 12px; /* 👈 по макету */
   }
 }
 
@@ -74,18 +93,6 @@
   .container {
     max-width: 1440px;
     padding: 0 108px;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .copyright {
-    margin: 0;
-  }
-
-  .nav {
-    flex-direction: row;
-    gap: 32px;
   }
 }
 
@@ -98,7 +105,6 @@
 }
 
 .modalActions button {
-  border: 1px solid #000;
   border-radius: 8px;
   padding: 12px 20px;
   font-size: 16px;
@@ -109,7 +115,8 @@
 
 .modalActions button:first-child {
   background: none;
-  color: #000;
+  border: 1px solid #000;
+  color: #000; /* 👈 чорний текст для Cancel */
 }
 
 .modalActions button:first-child:hover {

--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -14,6 +14,15 @@
   text-align: center;
 }
 
+.logo {
+  height: 24px;
+  cursor: pointer;
+}
+
+@media (min-width: 768px) {
+  .logo { height: 28px; }
+}
+
 .copyright {
   font-size: 12px;
   font-weight: 400;
@@ -39,7 +48,12 @@
 
 .link:hover,
 .link:focus-visible {
-  color: #f5e4d0; /* легке підсвічування */
+  color: #f5e4d0; 
+}
+
+.link:focus-visible {
+  outline: 2px solid #ffffffcc;
+  outline-offset: 3px;
 }
 
 /* ==== Tablet ==== */
@@ -110,4 +124,12 @@
 
 .modalActions button:last-child:hover {
   background-color: #a10f0f;
+}
+
+/* ==== Reduced motion ==== */
+@media (prefers-reduced-motion: reduce) {
+  .link,
+  .modalActions button {
+    transition: none !important;
+  }
 }

--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -4,6 +4,7 @@
   padding: 24px 0;
 }
 
+
 .container {
   max-width: 393px;
   margin: 0 auto;
@@ -15,128 +16,101 @@
   gap: 24px;
 }
 
+
 .logoBlock {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 8px;
   cursor: pointer;
 }
-
-.logo {
-  height: 24px;
-}
-
+.logo { width: 24px; height: 24px; }
 .logoText {
-  font-size: 14px;
+  font-family: "Montserrat", sans-serif;
   font-weight: 600;
-  font-family: inherit;
+  font-size: 18px;
+  line-height: 100%;
+  letter-spacing: -0.03em;
   color: #fff;
 }
 
-.copyright {
-  font-size: 12px;
-  font-weight: 400;
-  margin: 0;
-  color: rgba(255, 255, 255, 0.7); /* 👈 як у макеті, не чисто білий */
-}
 
 .nav {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 44px; /* 👈 по макету */
+  gap: 40px;
   font-size: 16px;
   font-weight: 600;
 }
+
 
 .link {
   color: #fff;
   text-decoration: none;
   cursor: pointer;
-  transition: color 0.3s ease;
+  font-size: 14px;
+  line-height: 20px;
+  transition: color .2s ease, opacity .2s ease;
 }
-
 .link:hover,
-.link:focus-visible {
-  color: #f5e4d0;
-}
-
+.link:focus-visible { color: #f5e4d0; }
 .link:focus-visible {
   outline: 2px solid #ffffffcc;
   outline-offset: 3px;
+  border-radius: 6px;
 }
 
-/* ==== Tablet ==== */
+
+button.link {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+}
+
+
+.copyright {
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
+  margin: 0;
+  color: rgba(255,255,255,0.7);
+}
+
+
 @media (min-width: 768px) {
   .container {
     max-width: 768px;
     padding: 0 32px;
-    flex-direction: row;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 1fr auto; 
     align-items: center;
     text-align: left;
+    gap: 24px;
   }
 
-  .logo {
-    height: 28px;
-  }
+  .logo { width: 28px; height: 28px; }
 
   .nav {
     flex-direction: row;
     gap: 32px;
-    font-size: 12px; /* 👈 по макету */
+    justify-self: end; 
+  }
+
+
+  .link {
+    font-size: 12px;
+    line-height: 16px;
+    letter-spacing: -0.01em; 
   }
 }
 
-/* ==== Desktop ==== */
 @media (min-width: 1440px) {
   .container {
     max-width: 1440px;
     padding: 0 108px;
+    grid-template-columns: 1fr auto; 
   }
 }
 
-/* ==== Modal Actions ==== */
-.modalActions {
-  display: flex;
-  justify-content: center;
-  gap: 16px;
-  margin-top: 24px;
-}
-
-.modalActions button {
-  border-radius: 8px;
-  padding: 12px 20px;
-  font-size: 16px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.3s ease;
-}
-
-.modalActions button:first-child {
-  background: none;
-  border: 1px solid #000;
-  color: #000; /* 👈 чорний текст для Cancel */
-}
-
-.modalActions button:first-child:hover {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-
-.modalActions button:last-child {
-  background-color: #c80000;
-  color: #fff;
-  border: none;
-}
-
-.modalActions button:last-child:hover {
-  background-color: #a10f0f;
-}
-
-/* ==== Reduced motion ==== */
-@media (prefers-reduced-motion: reduce) {
-  .link,
-  .modalActions button {
-    transition: none !important;
-  }
-}

--- a/src/components/Header/BurgerMenu/BurgerMenu.jsx
+++ b/src/components/Header/BurgerMenu/BurgerMenu.jsx
@@ -12,12 +12,14 @@ export default function BurgerMenu({ isOpen, onToggle }) {
     >
       <svg
         className={isOpen ? css.closeIcon : css.burgerIcon}
-        width="24"
-        height="24"
+        width={isOpen ? 22 : 20}
+        height={isOpen ? 22 : 14}
         aria-hidden="true"
         focusable="false"
       >
-        <use href={isOpen ? "/icons.svg#icon-close" : "/icons.svg#icon-burger"}></use>
+        <use
+          href={isOpen ? "/icons.svg#icon-close-circle" : "/icons.svg#icon-burger"}
+        ></use>
       </svg>
     </button>
   );

--- a/src/components/Header/BurgerMenu/BurgerMenu.jsx
+++ b/src/components/Header/BurgerMenu/BurgerMenu.jsx
@@ -1,4 +1,3 @@
-import Icon from "../../shared/Icon/Icon";
 import css from "./BurgerMenu.module.css";
 
 export default function BurgerMenu({ isOpen, onToggle }) {
@@ -8,11 +7,18 @@ export default function BurgerMenu({ isOpen, onToggle }) {
       className={isOpen ? css.closeBtn : css.burgerBtn}
       onClick={onToggle}
       aria-label={isOpen ? "Close menu" : "Open menu"}
+      aria-expanded={!!isOpen}
+      aria-controls="mobile-nav"
     >
-      <Icon
-        name={isOpen ? "close" : "burger"}
+      <svg
         className={isOpen ? css.closeIcon : css.burgerIcon}
-      />
+        width="24"
+        height="24"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <use href={isOpen ? "/icons.svg#icon-close" : "/icons.svg#icon-burger"}></use>
+      </svg>
     </button>
   );
 }

--- a/src/components/Header/BurgerMenu/BurgerMenu.jsx
+++ b/src/components/Header/BurgerMenu/BurgerMenu.jsx
@@ -1,0 +1,18 @@
+import Icon from "../../shared/Icon/Icon";
+import css from "./BurgerMenu.module.css";
+
+export default function BurgerMenu({ isOpen, onToggle }) {
+  return (
+    <button
+      type="button"
+      className={isOpen ? css.closeBtn : css.burgerBtn}
+      onClick={onToggle}
+      aria-label={isOpen ? "Close menu" : "Open menu"}
+    >
+      <Icon
+        name={isOpen ? "close" : "burger"}
+        className={isOpen ? css.closeIcon : css.burgerIcon}
+      />
+    </button>
+  );
+}

--- a/src/components/Header/BurgerMenu/BurgerMenu.module.css
+++ b/src/components/Header/BurgerMenu/BurgerMenu.module.css
@@ -1,0 +1,64 @@
+.burgerBtn,
+.closeBtn {
+  background: none;
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;           
+  height: 44px;
+  cursor: pointer;
+  color: #fff;         
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.burgerBtn:hover,
+.closeBtn:hover {
+  opacity: 0.9;
+}
+
+.burgerBtn:active,
+.closeBtn:active {
+  transform: scale(0.96);
+}
+
+
+.burgerBtn:focus-visible,
+.closeBtn:focus-visible {
+  outline: 2px solid #ffffffcc;
+  outline-offset: 2px;
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+  .burgerBtn,
+  .closeBtn {
+    transition: none;
+  }
+}
+
+/* === ICONS === */
+.burgerIcon {
+  width: 22px;
+  height: 16px;
+  fill: #fff;
+  stroke: #fff;
+}
+
+.closeIcon {
+  width: 14px;
+  height: 14px;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  fill: none;
+}
+
+
+/* ====   Планшет   ==== */
+@media (min-width: 768px) {
+  .burgerBtn,
+  .closeBtn {
+    display: none; 
+  }
+}

--- a/src/components/Header/BurgerMenu/BurgerMenu.module.css
+++ b/src/components/Header/BurgerMenu/BurgerMenu.module.css
@@ -5,16 +5,17 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 44px;           
+  width: 44px;
   height: 44px;
   cursor: pointer;
-  color: #fff;         
+  color: #fff;
   transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
 .burgerBtn:hover,
 .closeBtn:hover {
   opacity: 0.9;
+  color: #f5e4d0; 
 }
 
 .burgerBtn:active,
@@ -22,13 +23,11 @@
   transform: scale(0.96);
 }
 
-
 .burgerBtn:focus-visible,
 .closeBtn:focus-visible {
   outline: 2px solid #ffffffcc;
   outline-offset: 2px;
 }
-
 
 @media (prefers-reduced-motion: reduce) {
   .burgerBtn,
@@ -41,24 +40,24 @@
 .burgerIcon {
   width: 22px;
   height: 16px;
-  fill: #fff;
-  stroke: #fff;
+  stroke: currentColor;
+  fill: none;
 }
 
 .closeIcon {
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   stroke: currentColor;
   stroke-width: 1.6;
   stroke-linecap: round;
   fill: none;
 }
 
-
-/* ====   Планшет   ==== */
+/* ==== Tablet ==== */
 @media (min-width: 768px) {
   .burgerBtn,
   .closeBtn {
-    display: none; 
+    display: none;
   }
 }
+

--- a/src/components/Header/ConfirmLogoutModal/ConfirmLogoutModal.jsx
+++ b/src/components/Header/ConfirmLogoutModal/ConfirmLogoutModal.jsx
@@ -1,6 +1,5 @@
 import { createPortal } from "react-dom";
 import { useEffect } from "react";
-import Icon from "../../shared/Icon/Icon";
 import css from "./ConfirmLogoutModal.module.css";
 
 export default function ConfirmLogoutModal({ onClose, onConfirm }) {
@@ -29,7 +28,15 @@ export default function ConfirmLogoutModal({ onClose, onConfirm }) {
           onClick={onClose}
           aria-label="Close"
         >
-          <Icon name="close" className={css.closeIcon} />
+          <svg
+            className={css.closeIcon}
+            width="16"
+            height="16"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <use href="/icons.svg#icon-close"></use>
+          </svg>
         </button>
 
         <div className={css.content}>
@@ -49,4 +56,6 @@ export default function ConfirmLogoutModal({ onClose, onConfirm }) {
     document.body
   );
 }
+
+
 

--- a/src/components/Header/ConfirmLogoutModal/ConfirmLogoutModal.jsx
+++ b/src/components/Header/ConfirmLogoutModal/ConfirmLogoutModal.jsx
@@ -1,0 +1,52 @@
+import { createPortal } from "react-dom";
+import { useEffect } from "react";
+import Icon from "../../shared/Icon/Icon";
+import css from "./ConfirmLogoutModal.module.css";
+
+export default function ConfirmLogoutModal({ onClose, onConfirm }) {
+  useEffect(() => {
+    const handleEsc = (e) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", handleEsc);
+    return () => window.removeEventListener("keydown", handleEsc);
+  }, [onClose]);
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  return createPortal(
+    <div
+      className={css.overlay}
+      onClick={handleOverlayClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="dialog-title"
+    >
+      <div className={css.modal}>
+        <button
+          type="button"
+          className={css.closeBtn}
+          onClick={onClose}
+          aria-label="Close"
+        >
+          <Icon name="close" className={css.closeIcon} />
+        </button>
+
+        <div className={css.content}>
+          <h2 id="dialog-title" className={css.title}>Are you sure?</h2>
+          <p className={css.text}>We will miss you!</p>
+          <div className={css.actions}>
+            <button type="button" className={css.cancelBtn} onClick={onClose}>
+              Cancel
+            </button>
+            <button type="button" className={css.logoutBtn} onClick={onConfirm}>
+              Log out
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+

--- a/src/components/Header/ConfirmLogoutModal/ConfirmLogoutModal.module.css
+++ b/src/components/Header/ConfirmLogoutModal/ConfirmLogoutModal.module.css
@@ -28,19 +28,12 @@
   background: none;
   border: none;
   cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 4px;       
-  color: #000;        
 }
-
-.closeBtn:hover { color: #c80000; }
 
 .closeIcon {
   width: 16px;
   height: 16px;
-  stroke: currentColor;
+  stroke: #000;
   stroke-width: 2;
   fill: none;
 }
@@ -81,15 +74,11 @@
   font-weight: 600;
   font-size: 18px;
   cursor: pointer;
+  color: #000; /* ВАЖЛИВО: чорний текст */
 }
 
 .cancelBtn:hover {
   background-color: rgba(0, 0, 0, 0.05);
-}
-
-.cancelBtn:focus-visible {
-  outline: 2px solid #000;
-  outline-offset: 2px;
 }
 
 .logoutBtn {
@@ -109,14 +98,19 @@
 
 .logoutBtn:focus-visible {
   background-color: #c80000;
-  box-shadow:
-    0 0 0 6px rgba(200, 0, 0, 0.2),
-    0 0 0 2px #fff;
+  box-shadow: 0 0 0 6px rgba(200, 0, 0, 0.2), 0 0 0 2px #fff;
 }
 
 @media screen and (min-width: 768px) {
-  .modal { padding: 56px 32px 32px; }
-  .actions { flex-direction: row; justify-content: center; }
+  .modal {
+    padding: 56px 32px 32px;
+  }
+
+  .actions {
+    flex-direction: row;
+    justify-content: center;
+  }
+
   .cancelBtn,
   .logoutBtn {
     width: 164px;

--- a/src/components/Header/ConfirmLogoutModal/ConfirmLogoutModal.module.css
+++ b/src/components/Header/ConfirmLogoutModal/ConfirmLogoutModal.module.css
@@ -28,12 +28,19 @@
   background: none;
   border: none;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;       
+  color: #000;        
 }
+
+.closeBtn:hover { color: #c80000; }
 
 .closeIcon {
   width: 16px;
   height: 16px;
-  stroke: #000;
+  stroke: currentColor;
   stroke-width: 2;
   fill: none;
 }
@@ -80,6 +87,11 @@
   background-color: rgba(0, 0, 0, 0.05);
 }
 
+.cancelBtn:focus-visible {
+  outline: 2px solid #000;
+  outline-offset: 2px;
+}
+
 .logoutBtn {
   border: none;
   border-radius: 8px;
@@ -103,15 +115,8 @@
 }
 
 @media screen and (min-width: 768px) {
-  .modal {
-    padding: 56px 32px 32px;
-  }
-
-  .actions {
-    flex-direction: row;
-    justify-content: center;
-  }
-
+  .modal { padding: 56px 32px 32px; }
+  .actions { flex-direction: row; justify-content: center; }
   .cancelBtn,
   .logoutBtn {
     width: 164px;

--- a/src/components/Header/ConfirmLogoutModal/ConfirmLogoutModal.module.css
+++ b/src/components/Header/ConfirmLogoutModal/ConfirmLogoutModal.module.css
@@ -1,0 +1,122 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.modal {
+  position: relative;
+  background-color: #faf3e0;
+  border-radius: 24px;
+  padding: 56px 24px 32px;
+  width: 90%;
+  max-width: 420px;
+  text-align: center;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.closeBtn {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.closeIcon {
+  width: 16px;
+  height: 16px;
+  stroke: #000;
+  stroke-width: 2;
+  fill: none;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: center;
+}
+
+.title {
+  font-size: 32px;
+  font-weight: 600;
+  color: #000;
+}
+
+.text {
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.6;
+  color: #000;
+}
+
+.actions {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-direction: column;
+  width: 100%;
+}
+
+.cancelBtn {
+  border: 1px solid #000;
+  border-radius: 8px;
+  padding: 16px;
+  background: none;
+  font-weight: 600;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.cancelBtn:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.logoutBtn {
+  border: none;
+  border-radius: 8px;
+  padding: 16px;
+  background-color: #c80000;
+  color: #fff;
+  font-weight: 600;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.logoutBtn:hover {
+  background-color: #a10f0f;
+}
+
+.logoutBtn:focus-visible {
+  background-color: #c80000;
+  box-shadow:
+    0 0 0 6px rgba(200, 0, 0, 0.2),
+    0 0 0 2px #fff;
+}
+
+@media screen and (min-width: 768px) {
+  .modal {
+    padding: 56px 32px 32px;
+  }
+
+  .actions {
+    flex-direction: row;
+    justify-content: center;
+  }
+
+  .cancelBtn,
+  .logoutBtn {
+    width: 164px;
+    height: 44px;
+    padding: 12px 24px;
+    font-size: 16px;
+  }
+}

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -4,7 +4,6 @@ import { useSelector, useDispatch } from "react-redux";
 import { selectUser } from "../../redux/auth/selectors";
 import { fetchLogoutUser } from "../../redux/auth/operations";
 
-import Logo from "../Logo/Logo";
 import BurgerMenu from "./BurgerMenu/BurgerMenu";
 import Navigation from "./Navigation/Navigation";
 
@@ -25,14 +24,14 @@ export default function Header() {
   );
 
   useEffect(() => {
-    setMenuOpen(false); // закриваємо меню при зміні роуту
+    setMenuOpen(false); 
   }, [location.pathname]);
 
   const handleLogout = useCallback(async () => {
     try {
       await dispatch(fetchLogoutUser());
     } catch (_) {
-      // ignore error
+      // ignore
     } finally {
       localStorage.removeItem("token");
       localStorage.removeItem("user");
@@ -44,7 +43,14 @@ export default function Header() {
   return (
     <header className={css.header}>
       <div className={css.container}>
-        <Logo />
+        {}
+        <img
+          src="/assets/img/logo.svg"
+          alt="Logo"
+          className={css.logo}
+          onClick={() => navigate("/")}
+          style={{ cursor: "pointer" }}
+        />
 
         <BurgerMenu isOpen={menuOpen} onToggle={() => setMenuOpen(!menuOpen)} />
 
@@ -61,7 +67,7 @@ export default function Header() {
       </div>
 
       {menuOpen && (
-        <div className={`${css.mobileMenu} ${css.open}`}>
+        <div id="mobile-nav" className={`${css.mobileMenu} ${css.open}`}>
           <Navigation
             isLoggedIn={isLoggedIn}
             closeMenu={() => setMenuOpen(false)}
@@ -75,5 +81,6 @@ export default function Header() {
     </header>
   );
 }
+
 
 

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,3 +1,79 @@
+import { useState, useMemo, useCallback, useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useSelector, useDispatch } from "react-redux";
+import { selectUser } from "../../redux/auth/selectors";
+import { fetchLogoutUser } from "../../redux/auth/operations";
+
+import Logo from "../Logo/Logo";
+import BurgerMenu from "./BurgerMenu/BurgerMenu";
+import Navigation from "./Navigation/Navigation";
+
+import css from "./Header.module.css";
+
 export default function Header() {
-  return;
+  const [menuOpen, setMenuOpen] = useState(false);
+  const user = useSelector(selectUser);
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const isLoggedIn = Boolean(user);
+  const userName = user?.name || "Guest";
+  const userInitial = useMemo(
+    () => (userName?.trim()?.[0]?.toUpperCase() || "U"),
+    [userName]
+  );
+
+  useEffect(() => {
+    setMenuOpen(false); // закриваємо меню при зміні роуту
+  }, [location.pathname]);
+
+  const handleLogout = useCallback(async () => {
+    try {
+      await dispatch(fetchLogoutUser());
+    } catch (_) {
+      // ignore error
+    } finally {
+      localStorage.removeItem("token");
+      localStorage.removeItem("user");
+      navigate("/");
+      setMenuOpen(false);
+    }
+  }, [dispatch, navigate]);
+
+  return (
+    <header className={css.header}>
+      <div className={css.container}>
+        <Logo />
+
+        <BurgerMenu isOpen={menuOpen} onToggle={() => setMenuOpen(!menuOpen)} />
+
+        <div className={css.desktopNav}>
+          <Navigation
+            isLoggedIn={isLoggedIn}
+            closeMenu={() => {}}
+            userName={userName}
+            userInitial={userInitial}
+            onLogout={handleLogout}
+            isMobile={false}
+          />
+        </div>
+      </div>
+
+      {menuOpen && (
+        <div className={`${css.mobileMenu} ${css.open}`}>
+          <Navigation
+            isLoggedIn={isLoggedIn}
+            closeMenu={() => setMenuOpen(false)}
+            userName={userName}
+            userInitial={userInitial}
+            onLogout={handleLogout}
+            isMobile={true}
+          />
+        </div>
+      )}
+    </header>
+  );
 }
+
+

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,9 +1,10 @@
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 import { selectUser } from "../../redux/auth/selectors";
 import { fetchLogoutUser } from "../../redux/auth/operations";
 
+import Logo from "../../assets/img/logo.svg";
 import BurgerMenu from "./BurgerMenu/BurgerMenu";
 import Navigation from "./Navigation/Navigation";
 
@@ -18,13 +19,9 @@ export default function Header() {
 
   const isLoggedIn = Boolean(user);
   const userName = user?.name || "Guest";
-  const userInitial = useMemo(
-    () => (userName?.trim()?.[0]?.toUpperCase() || "U"),
-    [userName]
-  );
 
   useEffect(() => {
-    setMenuOpen(false); 
+    setMenuOpen(false);
   }, [location.pathname]);
 
   const handleLogout = useCallback(async () => {
@@ -41,16 +38,12 @@ export default function Header() {
   }, [dispatch, navigate]);
 
   return (
-    <header className={css.header}>
+    <header className={`${css.header} ${menuOpen ? css.menuOpen : ""}`}>
       <div className={css.container}>
-        {}
-        <img
-          src="/assets/img/logo.svg"
-          alt="Logo"
-          className={css.logo}
-          onClick={() => navigate("/")}
-          style={{ cursor: "pointer" }}
-        />
+        <div className={css.logoBlock} onClick={() => navigate("/")}>
+          <img src={Logo} alt="Logo" className={css.logo} />
+          <span className={css.logoText}>CookingCompanion</span>
+        </div>
 
         <BurgerMenu isOpen={menuOpen} onToggle={() => setMenuOpen(!menuOpen)} />
 
@@ -59,7 +52,6 @@ export default function Header() {
             isLoggedIn={isLoggedIn}
             closeMenu={() => {}}
             userName={userName}
-            userInitial={userInitial}
             onLogout={handleLogout}
             isMobile={false}
           />
@@ -67,20 +59,18 @@ export default function Header() {
       </div>
 
       {menuOpen && (
-        <div id="mobile-nav" className={`${css.mobileMenu} ${css.open}`}>
-          <Navigation
-            isLoggedIn={isLoggedIn}
-            closeMenu={() => setMenuOpen(false)}
-            userName={userName}
-            userInitial={userInitial}
-            onLogout={handleLogout}
-            isMobile={true}
-          />
+        <div className={`${css.mobileMenu} ${css.open}`} id="mobile-nav">
+          <div className={css.container}>
+            <Navigation
+              isLoggedIn={isLoggedIn}
+              closeMenu={() => setMenuOpen(false)}
+              userName={userName}
+              onLogout={handleLogout}
+              isMobile={true}
+            />
+          </div>
         </div>
       )}
     </header>
   );
 }
-
-
-

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,0 +1,60 @@
+.header {
+  padding: 14px 0;
+  background-color: #3d2218;
+  position: relative;
+  color: white;
+}
+
+.container {
+  max-width: 393px;
+  width: 100%;
+  padding: 0 16px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  text-align: left;
+}
+
+.desktopNav {
+  display: none;
+}
+
+.mobileMenu {
+  display: none;
+}
+
+.mobileMenu.open {
+  width: 100%;
+  padding: 32px 16px 26px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  background-color: #3d2218;
+  z-index: 999;
+  transition: all 0.3s ease-in-out;
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+    padding: 0 32px;
+    text-align: center;
+  }
+
+  .desktopNav {
+    display: block;
+  }
+
+  .mobileMenu.open {
+    display: none;
+  }
+}
+
+@media (min-width: 1440px) {
+  .container {
+    max-width: 1440px;
+    padding: 0 108px;
+  }
+}

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -5,6 +5,11 @@
   position: relative;
   color: #fff;
   z-index: 1000;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.menuOpen {
+  box-shadow: none;
 }
 
 .container {
@@ -15,7 +20,24 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  text-align: left;
+}
+
+.logoBlock {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.logo {
+  height: 24px;
+}
+
+.logoText {
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  color: #fff;
 }
 
 .desktopNav {
@@ -28,13 +50,9 @@
 
 .mobileMenu.open {
   position: absolute;
-  top: 100%; 
+  top: 100%;
   left: 0;
   width: 100%;
-  padding: 32px 16px 26px;
-  display: flex;
-  flex-direction: column;
-  text-align: center;
   background-color: #3d2218;
   z-index: 999;
   opacity: 1;
@@ -42,24 +60,24 @@
   transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
-
-.mobileMenu:not(.open) {
-  opacity: 0;
-  transform: translateY(-10px);
-  pointer-events: none;
+.mobileMenu.open .container {
+  padding: 32px 16px 40px;
+  flex-direction: column;
+  text-align: center;
 }
 
 @media (min-width: 768px) {
   .container {
     max-width: 768px;
     padding: 0 32px;
-    text-align: center;
+  }
+
+  .logo {
+    height: 28px;
   }
 
   .desktopNav {
-    display: flex;
-    align-items: center;
-    gap: 32px;
+    display: block;
   }
 
   .mobileMenu,
@@ -74,3 +92,4 @@
     padding: 0 108px;
   }
 }
+

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,8 +1,10 @@
 .header {
+  width: 100%;
   padding: 14px 0;
   background-color: #3d2218;
   position: relative;
-  color: white;
+  color: #fff;
+  z-index: 1000;
 }
 
 .container {
@@ -25,15 +27,26 @@
 }
 
 .mobileMenu.open {
+  position: absolute;
+  top: 100%; 
+  left: 0;
   width: 100%;
   padding: 32px 16px 26px;
-  margin: 0 auto;
   display: flex;
   flex-direction: column;
   text-align: center;
   background-color: #3d2218;
   z-index: 999;
-  transition: all 0.3s ease-in-out;
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+
+.mobileMenu:not(.open) {
+  opacity: 0;
+  transform: translateY(-10px);
+  pointer-events: none;
 }
 
 @media (min-width: 768px) {
@@ -44,11 +57,14 @@
   }
 
   .desktopNav {
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 32px;
   }
 
+  .mobileMenu,
   .mobileMenu.open {
-    display: none;
+    display: none !important;
   }
 }
 

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -13,7 +13,7 @@
 }
 
 .container {
-  max-width: 393px;
+  max-width: 393px; 
   width: 100%;
   padding: 0 16px;
   margin: 0 auto;
@@ -30,13 +30,16 @@
 }
 
 .logo {
+  width: 24px; 
   height: 24px;
 }
 
 .logoText {
-  font-size: 14px;
-  font-weight: 600;
-  font-family: inherit;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 600;          
+  font-size: 18px;           
+  line-height: 100%;        
+  letter-spacing: -0.03em;   
   color: #fff;
 }
 
@@ -44,7 +47,11 @@
   display: none;
 }
 
+/* ==== Mobile menu ==== */
 .mobileMenu {
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
   display: none;
 }
 
@@ -57,7 +64,7 @@
   z-index: 999;
   opacity: 1;
   transform: translateY(0);
-  transition: opacity 0.3s ease, transform 0.3s ease;
+  display: block;
 }
 
 .mobileMenu.open .container {
@@ -66,6 +73,18 @@
   text-align: center;
 }
 
+/* ==== Burger button ==== */
+.burgerBtn {
+  background: none;
+  border: none;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: inherit;
+}
+
+/* Tablet */
 @media (min-width: 768px) {
   .container {
     max-width: 768px;
@@ -73,7 +92,13 @@
   }
 
   .logo {
+    width: 28px;
     height: 28px;
+  }
+
+  .logoText {
+    font-size: 18px; 
+    line-height: 100%;
   }
 
   .desktopNav {
@@ -86,10 +111,14 @@
   }
 }
 
+/* Desktop */
 @media (min-width: 1440px) {
   .container {
     max-width: 1440px;
     padding: 0 108px;
   }
 }
+
+
+
 

--- a/src/components/Header/Navigation/Navigation.jsx
+++ b/src/components/Header/Navigation/Navigation.jsx
@@ -1,0 +1,81 @@
+import { NavLink } from "react-router-dom";
+import css from "./Navigation.module.css";
+import UserInfo from "../UserInfo/UserInfo";
+
+export default function Navigation({
+  isLoggedIn = false,
+  closeMenu = () => {},
+  userName = "",
+  userInitial = "U",
+  onLogout = () => {},
+  isMobile = false,
+}) {
+  return (
+    <nav className={css.navGroup}>
+      <NavLink
+        to="/"
+        className={({ isActive }) =>
+          `${css.link} ${css.recipes} ${isActive ? css.active : ""}`
+        }
+        onClick={closeMenu}
+      >
+        Рецепти
+      </NavLink>
+
+      {!isLoggedIn ? (
+        <>
+          <NavLink
+            to="/auth/login"
+            className={({ isActive }) =>
+              `${css.link} ${css.login} ${isActive ? css.active : ""}`
+            }
+            onClick={closeMenu}
+          >
+            Увійти
+          </NavLink>
+
+          <NavLink
+            to="/auth/register"
+            className={({ isActive }) =>
+              `${css.linkBtn} ${css.register} ${isActive ? css.active : ""}`
+            }
+            onClick={closeMenu}
+          >
+            Зареєструватися
+          </NavLink>
+        </>
+      ) : (
+        <>
+          <NavLink
+            to="/profile"
+            className={({ isActive }) =>
+              `${css.link} ${css.profile} ${isActive ? css.active : ""}`
+            }
+            onClick={closeMenu}
+          >
+            Мій профіль
+          </NavLink>
+
+          <NavLink
+            to="/add-recipe"
+            className={({ isActive }) =>
+              `${css.linkBtn} ${css.addRecipe} ${isActive ? css.active : ""}`
+            }
+            onClick={closeMenu}
+          >
+            Додати рецепт
+          </NavLink>
+
+          <div className={css.userInfo}>
+            <UserInfo
+              userName={userName}
+              userInitial={userInitial}
+              onLogout={onLogout}
+              isMobile={isMobile}
+            />
+          </div>
+        </>
+      )}
+    </nav>
+  );
+}

--- a/src/components/Header/Navigation/Navigation.jsx
+++ b/src/components/Header/Navigation/Navigation.jsx
@@ -19,7 +19,7 @@ export default function Navigation({
         }
         onClick={closeMenu}
       >
-        Рецепти
+        Recipes
       </NavLink>
 
       {!isLoggedIn ? (
@@ -31,7 +31,7 @@ export default function Navigation({
             }
             onClick={closeMenu}
           >
-            Увійти
+            Log in
           </NavLink>
 
           <NavLink
@@ -41,7 +41,7 @@ export default function Navigation({
             }
             onClick={closeMenu}
           >
-            Зареєструватися
+            Register
           </NavLink>
         </>
       ) : (
@@ -53,7 +53,7 @@ export default function Navigation({
             }
             onClick={closeMenu}
           >
-            Мій профіль
+            My Profile
           </NavLink>
 
           <NavLink
@@ -63,7 +63,7 @@ export default function Navigation({
             }
             onClick={closeMenu}
           >
-            Додати рецепт
+            Add Recipe
           </NavLink>
 
           <div className={css.userInfo}>
@@ -79,3 +79,4 @@ export default function Navigation({
     </nav>
   );
 }
+

--- a/src/components/Header/Navigation/Navigation.module.css
+++ b/src/components/Header/Navigation/Navigation.module.css
@@ -1,4 +1,3 @@
-/* Контейнер для навігації + UserInfo */
 .navGroup {
   display: flex;
   flex-direction: column;
@@ -17,10 +16,15 @@
 }
 
 .link:hover {
-  color: #f5e4d0; /* легке світлішання */
+  color: #f5e4d0; 
 }
 
-/* Псевдоелемент для анімованого підкреслення */
+.link:focus-visible {
+  outline: 2px solid #ffffffcc;
+  outline-offset: 3px;
+}
+
+
 .link::after {
   content: "";
   position: absolute;
@@ -32,7 +36,12 @@
   transition: width 0.3s ease;
 }
 
-.link.active::after {
+.link.active::after,
+.link[aria-current="page"]::after {
+  width: 100%;
+}
+
+.link:hover::after {
   width: 100%;
 }
 
@@ -49,7 +58,8 @@
   text-align: center;
   transition:
     background 0.3s ease,
-    box-shadow 0.3s ease;
+    box-shadow 0.3s ease,
+    transform 0.1s ease;
   cursor: pointer;
 }
 
@@ -62,10 +72,8 @@
   outline-offset: 2px;
 }
 
-/* Порядок лінків + UserInfo на мобілці */
-.userInfo {
-  order: 2;
-  align-self: center;
+.linkBtn:active {
+  transform: translateY(1px);
 }
 
 .navGroup > .recipes { order: 0; }
@@ -108,4 +116,14 @@
     font-size: 16px;
   }
 }
+
+/* ==== Reduced motion ==== */
+@media (prefers-reduced-motion: reduce) {
+  .link,
+  .link::after,
+  .linkBtn {
+    transition: none !important;
+  }
+}
+
 

--- a/src/components/Header/Navigation/Navigation.module.css
+++ b/src/components/Header/Navigation/Navigation.module.css
@@ -1,3 +1,4 @@
+/* Контейнер для навігації + UserInfo */
 .navGroup {
   display: flex;
   flex-direction: column;
@@ -15,7 +16,8 @@
   transition: color 0.2s ease;
 }
 
-.link:hover {
+.link:hover,
+.link:focus-visible {
   color: #f5e4d0; 
 }
 
@@ -24,7 +26,7 @@
   outline-offset: 3px;
 }
 
-
+/* Псевдоелемент для анімованого підкреслення */
 .link::after {
   content: "";
   position: absolute;
@@ -56,10 +58,7 @@
   padding: 12px 16px;
   width: 100%;
   text-align: center;
-  transition:
-    background 0.3s ease,
-    box-shadow 0.3s ease,
-    transform 0.1s ease;
+  transition: background 0.3s ease, box-shadow 0.3s ease, transform 0.1s ease;
   cursor: pointer;
 }
 
@@ -76,9 +75,10 @@
   transform: translateY(1px);
 }
 
+/* Порядок елементів на мобілці */
 .navGroup > .recipes { order: 0; }
 .navGroup > .profile { order: 1; }
-.navGroup > .userInfo { order: 2; }
+.navGroup > .userInfo { order: 2; margin-bottom: 12px; } 
 .navGroup > .addRecipe { order: 3; }
 
 /* ==== Планшет ==== */
@@ -89,7 +89,7 @@
     justify-content: space-between;
     gap: 32px;
     flex-wrap: nowrap;
-    font-size: 14px;
+    font-size: 12px; 
   }
 
   .linkBtn {
@@ -107,13 +107,14 @@
   .navGroup > .userInfo {
     order: 3;
     margin-left: auto;
+    margin-bottom: 0;
   }
 }
 
 /* ==== Десктоп ==== */
 @media (min-width: 1024px) {
   .navGroup {
-    font-size: 16px;
+    font-size: 12px; 
   }
 }
 
@@ -126,4 +127,4 @@
   }
 }
 
-
+  

--- a/src/components/Header/Navigation/Navigation.module.css
+++ b/src/components/Header/Navigation/Navigation.module.css
@@ -1,4 +1,5 @@
-/* Контейнер для навігації + UserInfo */
+
+/* БАЗА: мобільний */
 .navGroup {
   display: flex;
   flex-direction: column;
@@ -8,25 +9,28 @@
   font-weight: 600;
 }
 
+/* Лінки */
 .link {
   position: relative;
   padding-bottom: 4px;
   text-decoration: none;
   color: #fff;
   transition: color 0.2s ease;
+  white-space: nowrap;
 }
 
 .link:hover,
 .link:focus-visible {
-  color: #f5e4d0; 
+  color: #f5e4d0;
 }
 
 .link:focus-visible {
   outline: 2px solid #ffffffcc;
   outline-offset: 3px;
+  border-radius: 8px;
 }
 
-/* Псевдоелемент для анімованого підкреслення */
+/* underline-ефект */
 .link::after {
   content: "";
   position: absolute;
@@ -37,94 +41,102 @@
   background-color: currentColor;
   transition: width 0.3s ease;
 }
-
 .link.active::after,
-.link[aria-current="page"]::after {
-  width: 100%;
-}
-
+.link[aria-current="page"]::after,
 .link:hover::after {
   width: 100%;
 }
 
-/* Кнопки (Register / Add Recipe) */
+/* Кнопки (Register, Add Recipe) */
 .linkBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%; 
+  min-height: 40px;
+  padding: 12px 16px;
   background-color: #9b6c43;
   color: #fff;
+  border: 1px solid transparent;
   border-radius: 8px;
-  border: none;
   font-size: 16px;
   font-weight: 600;
-  padding: 12px 16px;
-  width: 100%;
-  text-align: center;
-  transition: background 0.3s ease, box-shadow 0.3s ease, transform 0.1s ease;
+  text-decoration: none;
   cursor: pointer;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease, transform 0.1s ease;
 }
-
 .linkBtn:hover {
   background-color: #6d554b;
 }
-
 .linkBtn:focus-visible {
   outline: 2px solid #fff;
   outline-offset: 2px;
 }
-
 .linkBtn:active {
   transform: translateY(1px);
 }
 
-/* Порядок елементів на мобілці */
-.navGroup > .recipes { order: 0; }
-.navGroup > .profile { order: 1; }
-.navGroup > .userInfo { order: 2; margin-bottom: 12px; } 
-.navGroup > .addRecipe { order: 3; }
+/* Порядок елементів (мобілка) */
+.navGroup > .recipes  { order: 0; }
+.navGroup > .profile  { order: 1; }
+.navGroup > .userInfo { order: 2; margin-bottom: 12px; }
+.navGroup > .addRecipe{ order: 3; }
 
-/* ==== Планшет ==== */
+
 @media (min-width: 768px) {
   .navGroup {
     flex-direction: row;
     align-items: center;
-    justify-content: space-between;
-    gap: 32px;
+    justify-content: flex-start;
+    gap: 32px; 
     flex-wrap: nowrap;
-    font-size: 12px; 
+  }
+
+  .link {
+    font-size: 12px;         
+    line-height: 16px;
+    letter-spacing: -0.03em; 
+    font-weight: 500;        
+    padding: 8px 10px;
+    border-radius: 8px;
+  }
+  .link:hover {
+    background: rgba(255, 255, 255, 0.08);
   }
 
   .linkBtn {
     width: auto;
+    min-height: 36px;
+    padding: 10px 14px;
+    font-size: 12px;
+    line-height: 16px;
+    border-radius: 8px;
     white-space: nowrap;
+    background-color: #ffffff;
+    color: #3d2218;
+    border-color: #ffffff;
+  }
+  .linkBtn:hover {
+    background-color: #f4e9e4;
+    border-color: #f4e9e4;
   }
 
-  .link {
-    white-space: nowrap;
-  }
-
-  .navGroup > .recipes { order: 0; }
-  .navGroup > .profile { order: 1; }
-  .navGroup > .addRecipe { order: 2; }
-  .navGroup > .userInfo {
-    order: 3;
-    margin-left: auto;
-    margin-bottom: 0;
-  }
+  /* порядок елементів у рядку */
+  .navGroup > .recipes  { order: 0; }
+  .navGroup > .profile  { order: 1; }
+  .navGroup > .addRecipe{ order: 2; }
+  .navGroup > .userInfo { order: 3; margin-left: auto; margin-bottom: 0; }
 }
 
-/* ==== Десктоп ==== */
-@media (min-width: 1024px) {
-  .navGroup {
-    font-size: 12px; 
-  }
+/* === DESKTOP (>=1440px) === */
+@media (min-width: 1440px) {
+  .navGroup { gap: 20px; }
 }
 
-/* ==== Reduced motion ==== */
+/* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
-  .link,
-  .link::after,
-  .linkBtn {
+  .link, .link::after, .linkBtn {
     transition: none !important;
   }
 }
 
-  

--- a/src/components/Header/Navigation/Navigation.module.css
+++ b/src/components/Header/Navigation/Navigation.module.css
@@ -1,0 +1,111 @@
+/* Контейнер для навігації + UserInfo */
+.navGroup {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 36px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.link {
+  position: relative;
+  padding-bottom: 4px;
+  text-decoration: none;
+  color: #fff;
+  transition: color 0.2s ease;
+}
+
+.link:hover {
+  color: #f5e4d0; /* легке світлішання */
+}
+
+/* Псевдоелемент для анімованого підкреслення */
+.link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0%;
+  height: 2px;
+  background-color: currentColor;
+  transition: width 0.3s ease;
+}
+
+.link.active::after {
+  width: 100%;
+}
+
+/* Кнопки (Register / Add Recipe) */
+.linkBtn {
+  background-color: #9b6c43;
+  color: #fff;
+  border-radius: 8px;
+  border: none;
+  font-size: 16px;
+  font-weight: 600;
+  padding: 12px 16px;
+  width: 100%;
+  text-align: center;
+  transition:
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  cursor: pointer;
+}
+
+.linkBtn:hover {
+  background-color: #6d554b;
+}
+
+.linkBtn:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+/* Порядок лінків + UserInfo на мобілці */
+.userInfo {
+  order: 2;
+  align-self: center;
+}
+
+.navGroup > .recipes { order: 0; }
+.navGroup > .profile { order: 1; }
+.navGroup > .userInfo { order: 2; }
+.navGroup > .addRecipe { order: 3; }
+
+/* ==== Планшет ==== */
+@media (min-width: 768px) {
+  .navGroup {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 32px;
+    flex-wrap: nowrap;
+    font-size: 14px;
+  }
+
+  .linkBtn {
+    width: auto;
+    white-space: nowrap;
+  }
+
+  .link {
+    white-space: nowrap;
+  }
+
+  .navGroup > .recipes { order: 0; }
+  .navGroup > .profile { order: 1; }
+  .navGroup > .addRecipe { order: 2; }
+  .navGroup > .userInfo {
+    order: 3;
+    margin-left: auto;
+  }
+}
+
+/* ==== Десктоп ==== */
+@media (min-width: 1024px) {
+  .navGroup {
+    font-size: 16px;
+  }
+}
+

--- a/src/components/Header/UserInfo/UserInfo.jsx
+++ b/src/components/Header/UserInfo/UserInfo.jsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import css from "./UserInfo.module.css";
+import Icon from "../../shared/Icon/Icon";
+import ConfirmLogoutModal from "../ConfirmLogoutModal/ConfirmLogoutModal";
+
+export default function UserInfo({ userName = "User", onLogout, className }) {
+  const [showModal, setShowModal] = useState(false);
+  const initial = userName?.trim()?.[0]?.toUpperCase() || "?";
+
+  return (
+    <div className={`${css.wrapper} ${className || ""}`}>
+      <div className={css.avatar}>{initial}</div>
+      <span className={css.name}>{userName || "Guest"}</span>
+      <div className={css.divider}></div>
+
+      <button
+        type="button"
+        className={css.logoutBtn}
+        onClick={() => setShowModal(true)}
+        aria-label="Logout"
+        title="Logout"
+      >
+        <Icon name="logout" className={css.logoutIcon} />
+      </button>
+
+      {showModal && (
+        <ConfirmLogoutModal
+          onClose={() => setShowModal(false)}
+          onConfirm={() => {
+            onLogout();
+            setShowModal(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+

--- a/src/components/Header/UserInfo/UserInfo.jsx
+++ b/src/components/Header/UserInfo/UserInfo.jsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import css from "./UserInfo.module.css";
-import Icon from "../../shared/Icon/Icon";
 import ConfirmLogoutModal from "../ConfirmLogoutModal/ConfirmLogoutModal";
 
 export default function UserInfo({ userName = "User", onLogout, className }) {
@@ -11,7 +10,7 @@ export default function UserInfo({ userName = "User", onLogout, className }) {
     <div className={`${css.wrapper} ${className || ""}`}>
       <div className={css.avatar}>{initial}</div>
       <span className={css.name}>{userName || "Guest"}</span>
-      <div className={css.divider}></div>
+      <div className={css.divider} />
 
       <button
         type="button"
@@ -20,14 +19,16 @@ export default function UserInfo({ userName = "User", onLogout, className }) {
         aria-label="Logout"
         title="Logout"
       >
-        <Icon name="logout" className={css.logoutIcon} />
+        <svg className={css.logoutIcon} width="17" height="17" aria-hidden="true" focusable="false">
+          <use href="/icons.svg#icon-exit"></use>
+        </svg>
       </button>
 
       {showModal && (
         <ConfirmLogoutModal
           onClose={() => setShowModal(false)}
           onConfirm={() => {
-            onLogout();
+            onLogout?.();
             setShowModal(false);
           }}
         />

--- a/src/components/Header/UserInfo/UserInfo.module.css
+++ b/src/components/Header/UserInfo/UserInfo.module.css
@@ -1,0 +1,64 @@
+.wrapper {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: center;
+  color: #fff;
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.avatar {
+  background-color: #9b6c43;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.name {
+  white-space: nowrap;
+}
+
+.divider {
+  width: 1px;
+  height: 24px;
+  background-color: #fff;
+}
+
+.logoutBtn {
+  background: none;
+  border: none;
+  padding: 0;
+  width: 24px;
+  height: 28px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.logoutBtn:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.logoutIcon {
+  width: 17px;
+  height: 17px;
+  stroke: #fff;
+  transition: stroke 0.3s;
+}
+
+.logoutBtn:hover .logoutIcon {
+  stroke: #ff4d4d; 
+}
+

--- a/src/components/Header/UserInfo/UserInfo.module.css
+++ b/src/components/Header/UserInfo/UserInfo.module.css
@@ -43,6 +43,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  color: #fff; 
 }
 
 .logoutBtn:focus-visible {
@@ -51,14 +52,15 @@
   border-radius: 4px;
 }
 
+.logoutBtn:hover {
+  color: #ff4d4d; 
+}
+
 .logoutIcon {
   width: 17px;
   height: 17px;
-  stroke: #fff;
+  stroke: currentColor; 
   transition: stroke 0.3s;
-}
-
-.logoutBtn:hover .logoutIcon {
-  stroke: #ff4d4d; 
+  fill: none;
 }
 

--- a/src/shared/Modal.jsx
+++ b/src/shared/Modal.jsx
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import ReactDOM from "react-dom";
+import s from "./Modal.module.scss";
+
+const modalRoot = document.getElementById("modal-root") || document.body;
+
+export default function Modal({ isOpen = true, onClose, title, children }) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEsc = (e) => e.key === "Escape" && onClose?.();
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return ReactDOM.createPortal(
+    <div className={s.backdrop} onClick={onClose} role="dialog" aria-modal="true">
+      <div className={s.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={s.header}>
+          {title && <h3 className={s.title}>{title}</h3>}
+          <button className={s.close} onClick={onClose} aria-label="Close">×</button>
+        </div>
+        <div className={s.content}>{children}</div>
+      </div>
+    </div>,
+    modalRoot
+  );
+}

--- a/src/shared/Modal.module.css
+++ b/src/shared/Modal.module.css
@@ -1,0 +1,103 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background-color: #3d2218; 
+  color: #fff;
+  width: min(480px, 92vw);
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  animation: fadeIn 0.3s ease;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.title {
+  margin: 0;
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 1.2;
+  font-family: "Montserrat", sans-serif;
+}
+
+.close {
+  border: none;
+  background: transparent;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  color: #fff;
+  transition: color 0.2s ease;
+}
+.close:hover,
+.close:focus-visible {
+  color: #f5e4d0;
+  outline: none;
+}
+
+.content {
+  padding: 20px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+
+.actions {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  padding: 16px 20px 24px;
+}
+
+.actions button {
+  border-radius: 8px;
+  padding: 10px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.actions button:first-child {
+  background: none;
+  border: 1px solid #fff;
+  color: #fff;
+}
+.actions button:first-child:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.actions button:last-child {
+  background-color: #9b6c43; 
+  border: none;
+  color: #fff;
+}
+.actions button:last-child:hover {
+  background-color: #6d554b;
+}
+.actions button:active {
+  transform: translateY(1px);
+}
+
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: scale(0.96); }
+  to { opacity: 1; transform: scale(1); }
+}


### PR DESCRIPTION
- Added Modal component with styles, fixed imports.  
- Replaced mock checks with real selector `selectIsAuthenticated`.  
- Updated Header: logo → Tasteorama, nav links 12px on tablet+, mobile menu fixed.  
- Updated Footer: 2-column grid on tablet, copyright Tasteorama, Account opens Modal.  
- Logout now uses thunk `fetchLogoutUser`.  
